### PR TITLE
Add support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ env:
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django110
-  - TOXENV=py34-django18
-  - TOXENV=py34-django19
-  - TOXENV=py34-django110
+  - TOXENV=py35-django18
+  - TOXENV=py35-django19
+  - TOXENV=py35-django110
   - TOXENV=pypy-django18
   - TOXENV=pypy-django19
   - TOXENV=pypy-django110

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,15 +9,15 @@ script:
   - tox
 
 env:
-  - TOXENV=py27-django17
   - TOXENV=py27-django18
   - TOXENV=py27-django19
-  - TOXENV=py34-django17
+  - TOXENV=py27-django110
   - TOXENV=py34-django18
   - TOXENV=py34-django19
-  - TOXENV=pypy-django17
+  - TOXENV=py34-django110
   - TOXENV=pypy-django18
   - TOXENV=pypy-django19
+  - TOXENV=pypy-django110
 
 after_success:
   - coveralls

--- a/django_smart_autoregister/django_helper.py
+++ b/django_smart_autoregister/django_helper.py
@@ -2,8 +2,6 @@
 """
 Module to wrap dirty stuff of django core.
 """
-from distutils.version import StrictVersion
-
 import django
 from django.db import models
 from django.db.models import *
@@ -17,11 +15,6 @@ except ImportError:
     pass # Django < 1.7
 
 
-def django_greater_than(version):
-    # Slice to avoid StrictVersion errors with versions like 1.8c1
-    DJANGO_VERSION = django.get_version()[0:3]
-    return StrictVersion(DJANGO_VERSION) >= StrictVersion(version)
-
 # Apps
 def get_apps(application_labels=[], exclude_application_labels=[]):
     """
@@ -33,7 +26,7 @@ def get_apps(application_labels=[], exclude_application_labels=[]):
     if application_labels:
         applications = []
         for app_label in application_labels:
-            if django_greater_than('1.7'):
+            if django.VERSION >= (1, 7):
                 app_config = apps.get_app_config(app_label)
                 applications.append(app_config.module)
             else:
@@ -43,7 +36,7 @@ def get_apps(application_labels=[], exclude_application_labels=[]):
     if exclude_application_labels:
         for app_label in exclude_application_labels:
             if app_label:
-                if django_greater_than('1.7'):
+                if django.VERSION >= (1, 7):
                     app_config = apps.get_app_config(app_label)
                     applications.remove(app_config.models_module)
                 else:
@@ -62,7 +55,7 @@ def get_models_of_an_app(app_module):
     """
     app_module is the object returned by get_apps method (python module)
     """
-    if django_greater_than('1.7'):
+    if django.VERSION >= (1, 7):
         app_name = get_app_name(app_module)
         app_config = apps.get_app_config(app_name)
         return list(app_config.get_models())
@@ -249,7 +242,7 @@ def is_file(field):
     return isinstance(field, (FileField, FilePathField))
 
 def is_binary(field):
-    if django_greater_than('1.6'):
+    if django.VERSION(1, 6):
         return isinstance(field, (BinaryField))
     else:
         return False

--- a/django_smart_autoregister/models_test.py
+++ b/django_smart_autoregister/models_test.py
@@ -3,7 +3,6 @@ import six
 import django
 from django.db import models
 from django.contrib.auth.models import User
-from .django_helper import django_greater_than
 
 
 class EmptyModel(models.Model):
@@ -47,7 +46,7 @@ class SomeModel(models.Model):
     file = models.FileField(upload_to='/tmp')
     filepath = models.FilePathField()
 
-    if django_greater_than('1.6'):
+    if django.VERSION >= (1, 6):
         binary = models.BinaryField()
 
     class Meta:

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    django17-py{27,34,py},
-    django18-py{27,34,py},
-    django19-py{27,34,py},
+    django18-py{27,35,py},
+    django19-py{27,35,py},
+    django110-py{27,35,py},
 
 [testenv]
 setenv =
@@ -15,18 +15,15 @@ setenv =
 
 basepython=
     py27: python2.7
-    py34: python3.4
+    py35: python3.5
     py36: python3.6
     pypy: pypy
 
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/requirements-dev.txt
-    django14: django>=1.4,<1.5
-    django15: django>=1.5,<1.6
-    django16: django>=1.6,<1.7
-    django17: django>=1.7,<1.8
     django18: django>=1.8,<1.9
     django19: django>=1.9,<1.10
+    django110: django>=1.10,<1.11
 
 commands = {toxinidir}/runtests.py


### PR DESCRIPTION
Using `django.VERSION` instead of custom utility method in order to access and compare the current Django version.